### PR TITLE
Set universal_newlines=True in DAS query to fix string format

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -185,6 +185,7 @@ def getFilesForDataset(dataset, site=None):
             time.sleep(100)
         p = Popen(query,
                   stdout=PIPE,
+                  universal_newlines=True,
                   shell=True)
         pipe = p.stdout.read()
         tupleP = os.waitpid(p.pid, 0)


### PR DESCRIPTION
While testing the submission on lxplus8 I found that the DAS query output does not get recognised properly. The output of the subprocess did not get recognized as ASCII:
```
b'/store/relval/CMSSW_12_5_1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun4_realistic_v2_D88noPU-v1/2580000/1394a5af-230c-4848-9a71-fac4322ba76d.root\n/store/relval/CMSSW_12_5_1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun4_realistic_v2_D88noPU-v1/2580000/3eb0e219-b1d4-4c3c-8b07-231ca1552027.root\n...
```

And hence messed up the file list. 

I found this solution to help: https://stackoverflow.com/a/48880977

Essentially setting `universal_newlines=True` in the `Popen` decodes the string (and newlines) properly.

p.s. If running on EL8/CC8 one has to add (see [here](https://batchdocs.web.cern.ch/local/submit.html#os-choice) the CERN Condor docs)
```
requirements = (OpSysAndVer =?= "CentOS8")
```

in the `condorSubmit_DEFAULT.sub` steering file.
I do not know of an easy way to make this configurable in the `yaml` since the `mode` is alreadt used for the job steering files..
