### PR TITLE
Add option to specify storage site and optionally specify the output directory.

### DIFF
--- a/submit_INFP_131X.yaml
+++ b/submit_INFP_131X.yaml
@@ -4,6 +4,7 @@ Common:
   name: fpinputs
   
   tasks:
+    # - DYToLL_M50_PU0
     # - DoubleElectron_FlatPt-1To100_PU0
     # - TT_PU200
     # # - DYToLL_PU200
@@ -21,6 +22,7 @@ Common:
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fpinputs
   ncpu: 1
   output_file_name: inputs131X.root
+  #storage_site: T2_UK_SGrid_RALPP
 
 # DoubleElectron_FlatPt-1To100_PU0:
 #   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
@@ -85,6 +87,13 @@ DYToLL_M10To50_PU200:
   job_flavor: longlunch
   max_events: 50000
 
+
+# DYToLL_M50_PU0:
+#   input_dataset: /DYToLL_M-50_TuneCP5_14TeV-pythia8/Phase2Spring23DIGIRECOMiniAOD-noPU_131X_mcRun4_realistic_v5-v1/GEN-SIM-DIGI-RAW-MINIAOD
+#   crab: True
+#   splitting_mode: Automatic
+#   splitting_granularity: 1000
+#   max_events: 50000
 
 DYToLL_M50_PU200:
   input_dataset: /DYToLL_M-50_TuneCP5_14TeV-pythia8/Phase2Spring23DIGIRECOMiniAOD-PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/GEN-SIM-DIGI-RAW-MINIAOD

--- a/templates/crab_INFP.py
+++ b/templates/crab_INFP.py
@@ -1,9 +1,6 @@
 from CRABClient.UserUtilities import config
 config = config()
 
-# config.General.requestName = 'SingleGammaPt25Eta1p6_2p8_PU0'
-# config.Data.inputDataset = '/SingleGammaPt25Eta1p6_2p8/PhaseIITDRFall17DR-noPUFEVT_93X_upgrade2023_realistic_v2-v1/GEN-SIM-DIGI-RAW'
-
 config.General.requestName = 'TEMPL_REQUESTNAME'
 config.Data.inputDataset = 'TEMPL_INPUTDATASET'
 config.Data.partialDataset = True
@@ -27,5 +24,5 @@ config.Data.publication = False
 config.Data.ignoreLocality = False
 config.Data.outputDatasetTag = 'TEMPL_DATASETTAG'
 
-config.Site.storageSite = 'T2_CH_CERN'
+config.Site.storageSite = 'TEMPL_STORAGE'
 config.JobType.allowUndistributedCMSSW = True


### PR DESCRIPTION
Code maintains backward compatibility. 

- Add option to specify the storage site using `storage_site` in yaml configuration file.
- Optionally specify the output directory in crab jobs.
   - If you specify the output directory starting with "/eos/cms", the modification used earlier is still valid to allow backward compatibility.
   - Throws a warning if you specify the option which is not "/eos/cms" to make the user aware of potential trouble. 
   - Throws an error if you specify condor and do not specify the output directory. 
- Some small deletions of unused code.