### PR TITLE
Add capability to submit HT-Condor tasks with more than 1 cmsRun step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ Each task corresponds to a sample.
 
 The tool supports:
 * **HT-Condor local submission**: each task will be mapped to a dedicated condor cluster.
-Input files can be specified via the dataset name using `input_dataset` or via the directory where the files sit using `input_directory`. The implemented input splitting modes are: `file_based` and `lumi_based` (in the sense of LS).
+Input files can be specified via the dataset name using one of:
+   * `input_dataset`: official DBS dataset name
+   * `input_directory`: directory where the files sit.
+   * `input_files`: the same file set is used for all jobs.
+   
+The implemented input splitting modes are: `file_based` (meant to work with `input_dataset` and `input_directory`),  `lumi_based` (in the sense of LS) and `events_ranges` (meant to work with `input_files`).
 For the `job_flavor` and other condor parameters please refer to the [CERN Condor documentation](http://batchdocs.web.cern.ch/batchdocs/local/index.html)
 
 * **CRAB remote submission**: this is controlled setting the `crab: True` parameter. In this case the input needs to be specified using `input_dataset` and for the configuration of `splitting_mode` and `splitting_granularity` you need to refer to the [CMS CRAB Sw Guide](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCrab). The rest of the parameters can be customized via the template file `crab_MODE.py` (see the documentation about the template structure in the following).
@@ -31,16 +36,15 @@ For the `job_flavor` and other condor parameters please refer to the [CERN Condo
 
 ## How to modify the template structure
 
-If you want to add a new set of templates you need to define a new mode (`MODE`) in:
+If you want to add a new set of templates you need to define a new mode (`MODE`) customizing the relevant files in the directory
+`templates/`.
 
-https://github.com/cerminar/submission/blob/master/submit.py#L101
+Note the code assumes that all string starting with `TEMPL_` are variables in the templated files that need to be replaced.
 
-Note the code assumes that all keys starting with `TEMPL_` are variables in the templated files that need to be replaced.
+The templated files are of 4 kinds:
+1. `condorSubmit_MODE.sub`: this defines the structure of the Condor submission file. If you don't need to modify it you can use the `condorSubmit_DEFAULT.sub` one (see [CERN Condor documentation](http://batchdocs.web.cern.ch/batchdocs/local/index.html)). (This is only used when submitting via HT-Condor).
+2. `jobCustomization_MODE_cfg.py.` which defines what needs to be changed for the configuration of each `cmsRun` job of the cluster. (This is only used when submitting via HT-Condor).
+3. `run_MODE.sh`: this is the script which actually gets executed on the node, setups the config and calls cmsRun. Again a `run_DEFAULT.sh` exists and should work for most cases. (This is only used when submitting via HT-Condor).
+4. `crab_MODE.py` is the templated crab configuration file.  (This is only used when submitting via Crab3).
 
-And create the corresponding template files in the directory
-`templates/`
-
-You need 1 or 2 templated files:
-1. `condorSubmit_MODE.sub`: this defines the structure of the Condor submission file. If you don't need to modify it you can use the `condorSubmit_DEFAULT.sub` one (see [CERN Condor documentation](http://batchdocs.web.cern.ch/batchdocs/local/index.html));
-2. `jobCustomization_MODE_cfg.py.` which defines what needs to be changed for each job of the cluster.
-3. `run_MODE.sh`: this is the script which actually gets executed on the node, setups the config and calls cmsRun. Again a `run_DEFAULT.sh` exists and should work for most cases.
+Note that if the yaml configuration defines a mode that is not implemented for a certain file the script will fall back to the corresponding file in `DEFAULT` mode.

--- a/submit.py
+++ b/submit.py
@@ -133,6 +133,10 @@ class TaskConfig:
                 common_config['mode'],
                 self.version)
         self.ncpu = common_config['ncpu']
+        if 'max_memory' in common_config.keys():
+            self.max_memory = common_config['max_memory']
+        else:
+            self.max_memory = 3000
         self.output_file_name = common_config['output_file_name']
         if 'storage_site' in common_config.keys():
             self.storage_site = common_config['storage_site']
@@ -299,6 +303,8 @@ def getJobParams(mode, task_conf):
         params['TEMPL_OUTFILE'] = task_conf.output_file_name
         params['TEMPL_OUTDIR'] = task_conf.output_dir
         params['TEMPL_NCPU'] = task_conf.ncpu
+
+        params['TEMPL_MEMORY'] = task_conf.max_memory
         params['TEMPL_SPLITGRANULARITY'] = task_conf.splitting_granularity
         params['TEMPL_SPLITTINGMODE'] = task_conf.splitting_mode
         params['TEMPL_REQUESTNAME'] = task_conf.task_name

--- a/submit.py
+++ b/submit.py
@@ -588,7 +588,15 @@ def printDoc(task_configs):
             ntp_repo = git.Repo(ntp_src)
             print(f'   * `{pkg}` git branch: `{ntp_repo.active_branch.name}`')
 
-    print(f'   * config file: `{task_configs[0].cmssw_config}`')
+    if len(task_configs[0].cmssw_configs) > 1:
+        print(f'   * config files:')
+        
+        for ic,conf in enumerate(task_configs[0].cmssw_configs):
+            print(f'       - step{ic}: `{conf["cmssw_config"]}`, mode: `{conf["mode"]}`')
+    else:
+        print(f'   * config file: `{task_configs[0].cmssw_configs[0]["cmssw_config"]}` mode: `{task_configs[0].cmssw_configs[0]["mode"]}`')
+
+
     print(f'   * tasks:')
     for task in task_configs:
         print(f'      * `{task.task_name}`')

--- a/submit_125X.yaml
+++ b/submit_125X.yaml
@@ -11,14 +11,16 @@ Common:
     # - DoublePhoton_FlatPt-1To100_PU200
     # - NuGunAllEta_PU200
     - ZprimeToEE_M-6000_PU200
-
-
-  # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
-  cmssw_config: ../FastPUPPI/NtupleProducer/python/runInputs125X.py
+  
   version: v100A
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/ntuples
   ncpu: 1
   output_file_name: ntuple.root
+
+Configuration:
+  - mode: NTP
+    cmssw_config: ../FastPUPPI/NtupleProducer/python/runInputs125X.py
+
 
 DoubleElectron_FlatPt-1To100_PU0:
   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD

--- a/submit_131X.yaml
+++ b/submit_131X.yaml
@@ -11,11 +11,15 @@ Common:
     # - DoublePhoton_FlatPt-1To100_PU200
     - NuGunAllEta_PU200
 
-  cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
   version: v92B
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/ntuples
   ncpu: 1
   output_file_name: ntuple.root
+
+Configuration:
+  - mode: NTP
+    cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
+
 
 # DoubleElectron_FlatPt-1To100_PU0:
 #   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD

--- a/submit_FP_125X.yaml
+++ b/submit_FP_125X.yaml
@@ -12,13 +12,14 @@ Common:
     - NuGunAllEta_PU200
     - ZprimeToEE_M-6000_PU200
 
-
-  # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
-  cmssw_config: ../FastPUPPI/NtupleProducer/python/runPerformanceNTuple.py
   version: v100C
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fp_ntuples
   ncpu: 1
   output_file_name: perfNano.root
+
+Configuration:
+  - mode: FP
+    cmssw_config: ../FastPUPPI/NtupleProducer/python/runPerformanceNTuple.py
 
 DoubleElectron_FlatPt-1To100_PU0:
   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD

--- a/submit_FP_131X.yaml
+++ b/submit_FP_131X.yaml
@@ -12,18 +12,20 @@ Common:
   name: fp
   
   tasks:
-    # - DoubleElectron_FlatPt-1To100_PU0
-    - TT_PU200
+    - DoubleElectron_FlatPt-1To100_PU0
+    # - TT_PU200
+    # - DYToLL_M-10To50_PU200
     # - DYToLL_M-50_PU200
     - DoubleElectron_FlatPt-1To100_PU200
-    - DoublePhoton_FlatPt-1To100_PU200
-    - NuGunAllEta_PU200
-    # - ZprimeToEE_M-6000_PU200
-
+    # # - DoublePhoton_FlatPt-1To100_PU200
+    # - NuGunAllEta_PU200
+    # # - ZprimeToEE_M-6000_PU200
+    # - HAHM_ZdToEE_m2_pu200
+    # - HAHM_ZdToEE_m5_pu200
+    # - HAHM_ZdToEE_m15_pu200
 
   # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
-  
-  version: v131Xv3I
+  version: v131Xv3DEBUG
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fp_ntuples
   ncpu: 1
   output_file_name: perfNano.root
@@ -33,15 +35,23 @@ Configuration:
     cmssw_config: ../FastPUPPI/NtupleProducer/python/runPerformanceNTuple.py
 
 DoubleElectron_FlatPt-1To100_PU0:
-  input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
-  # input_directory =
-  crab: True
-  splitting_mode: Automatic
-  splitting_granularity: 200
-  # job_flavor =
+  # input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
+  input_directory: /eos/cms/store/cmst3/group/l1tr/pviscone/inputs/DoubleElectron_FlatPt-1To100_PU0_131Xv3a
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 1
+  inline_customize: 
+    - noResp();
+    - addGenLep([11,22]);
+    - addTkEG();
+    - addHGCalTPs()
+    - addStaEG()
+    - noResp()
+    - addDecodedTk();
+    - addEGCrystalClusters();
+  job_flavor: workday
   max_events: -1
 
-  
 DoubleElectron_FlatPt-1To100_PU200:
   # input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
   input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v3/DoubleElectron_FlatPt-1To100_PU200
@@ -49,10 +59,14 @@ DoubleElectron_FlatPt-1To100_PU200:
   splitting_mode: file_based
   splitting_granularity: 2
   inline_customize: 
+    - noResp();
     - addGenLep([11,22]);
     - addTkEG();
+    - addHGCalTPs()
     - addStaEG()
     - noResp()
+    - addDecodedTk();
+    - addEGCrystalClusters();
   job_flavor: microcentury
   max_events: -1
 
@@ -87,14 +101,15 @@ NuGunAllEta_PU200:
   input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v3/SingleNeutrino_PU200
   crab: False
   splitting_mode: file_based
-  splitting_granularity: 2
+  splitting_granularity: 1
   inline_customize: 
+    - noResp();
     - addGenLep([11,22]);
     - addTkEG();
     - addHGCalTPs()
     - addStaEG()
     - noResp()
-    # - addSeededConeJets()
+    - addDecodedTk();
   job_flavor: microcentury
   max_events: -1
 
@@ -103,17 +118,36 @@ NuGunAllEta_PU200:
 # /DYToLL_M-10To50_TuneCP5_14TeV-pythia8/Phase2Fall22DRMiniAOD-noPU_Pilot_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
 # /DYToLL_M-50_TuneCP5_14TeV-pythia8/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
 
-DYToLL_M-50_PU200:
+DYToLL_M-10To50_PU200:
   # input_dataset =
-  input_directory: /eos/cms/store/cmst3/group/l1tr/gpetrucc/12_5_X/NewInputs125X/150223/DYToLL_M-50_PU200/
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v3/DYToLL_M-10To50_PU200
   crab: False
   splitting_mode: file_based
   splitting_granularity: 2
   inline_customize: 
     - addGenLep([11,22]);
     - addTkEG();
+    - addHGCalTPs()
+    - addStaEG()
     - noResp()
-    # - addSeededConeJets()
+    - addDecodedTk();
+  job_flavor: microcentury
+  max_events: -1
+
+
+DYToLL_M-50_PU200:
+  # input_dataset =
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v3/DYToLL_M-50_PU200
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 2
+  inline_customize: 
+    - addGenLep([11,22]);
+    - addTkEG();
+    - addHGCalTPs()
+    - addStaEG()
+    - noResp()
+    - addDecodedTk();
   job_flavor: microcentury
   max_events: -1
 
@@ -142,9 +176,10 @@ TT_PU200:
   splitting_granularity: 2
   inline_customize: 
     - addGenLep([11,22]);
+    - addHGCalTPs()
     - addTkEG();
     - noResp()
-    # - addSeededConeJets()
+    - addSeededConeJets('SC8')
   job_flavor: microcentury
   max_events: -1
 
@@ -161,3 +196,55 @@ ZprimeToEE_M-6000_PU200:
     - noResp()
   job_flavor: microcentury
   max_events: -1
+
+
+
+HAHM_ZdToEE_m2_pu200:
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fpinputs/HAHM_ZdToEE_m2_pu200/INFP/131Xv3d
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 2
+  job_flavor: microcentury
+  max_events: -1
+  # max_njobs: 4
+  inline_customize: 
+    - addGenLep([11,22]);
+    - addTkEG();
+    - addHGCalTPs()
+    - addStaEG()
+    - noResp()
+    - addDecodedTk();
+    # - addGenWeight();
+
+HAHM_ZdToEE_m5_pu200:
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fpinputs/HAHM_ZdToEE_m5_pu200/INFP/131Xv3d
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 2
+  job_flavor: microcentury
+  max_events: -1
+  # max_njobs: 4
+  inline_customize: 
+    - addGenLep([11,22]);
+    - addTkEG();
+    - addHGCalTPs()
+    - addStaEG()
+    - noResp()
+    - addDecodedTk();
+    # - addGenWeight();
+
+HAHM_ZdToEE_m15_pu200:
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fpinputs/HAHM_ZdToEE_m15_pu200/INFP/131Xv3d
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 2
+  job_flavor: microcentury
+  max_events: -1
+  inline_customize: 
+    - addGenLep([11,22]);
+    - addTkEG();
+    - addHGCalTPs()
+    - addStaEG()
+    - noResp()
+    - addDecodedTk();
+    # - addGenWeight();

--- a/submit_FP_131X.yaml
+++ b/submit_FP_131X.yaml
@@ -22,11 +22,15 @@ Common:
 
 
   # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
-  cmssw_config: ../FastPUPPI/NtupleProducer/python/runPerformanceNTuple.py
+  
   version: v131Xv3I
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fp_ntuples
   ncpu: 1
   output_file_name: perfNano.root
+
+Configuration:
+  - mode: FP
+    cmssw_config: ../FastPUPPI/NtupleProducer/python/runPerformanceNTuple.py
 
 DoubleElectron_FlatPt-1To100_PU0:
   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD

--- a/submit_GENSIM_131X.yaml
+++ b/submit_GENSIM_131X.yaml
@@ -1,0 +1,56 @@
+
+Common:
+  mode: 2STEPS
+  name: prod
+  
+  tasks:
+    - HAHM_ZdToEE_m2_pu200
+    - HAHM_ZdToEE_m5_pu200
+    - HAHM_ZdToEE_m15_pu200
+
+
+  # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
+  version: 131X_Phase2Spring23_FEVTDEBUGHLT_v0
+  output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/prod
+  ncpu: 4
+  output_file_name: prod_131X.root
+  #storage_site: T2_UK_SGrid_RALPP
+
+Configuration:
+  - mode: RAWSIM
+    cmssw_config: ../step1_cfg.py
+  - mode: FEVTDEBUGHLT
+    cmssw_config: ../step2_cfg.py
+
+HAHM_ZdToEE_m5_pu200:
+  # input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
+  input_files: 
+    - /store/cmst3/group/l1tr/gpetrucc/prod125X-lhe/HAHM_ZdToEE_M5.lhe
+  crab: False
+  splitting_mode: event_ranges
+  splitting_granularity: 250
+  job_flavor: workday
+  max_events: 10000
+  # max_njobs: 4
+
+HAHM_ZdToEE_m2_pu200:
+  # input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
+  input_files: 
+    - /store/cmst3/group/l1tr/gpetrucc/prod125X-lhe/HAHM_ZdToEE_M2.lhe
+  crab: False
+  splitting_mode: event_ranges
+  splitting_granularity: 250
+  job_flavor: workday
+  max_events: 10000
+  # max_njobs: 4
+
+HAHM_ZdToEE_m15_pu200:
+  # input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
+  input_files: 
+    - /store/cmst3/group/l1tr/gpetrucc/prod125X-lhe/HAHM_ZdToEE_M15.lhe
+  crab: False
+  splitting_mode: event_ranges
+  splitting_granularity: 250
+  job_flavor: workday
+  max_events: 10000
+  # max_njobs: 4

--- a/submit_INFP_125X.yaml
+++ b/submit_INFP_125X.yaml
@@ -14,11 +14,14 @@ Common:
 
 
   # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
-  cmssw_config: ../FastPUPPI/NtupleProducer/python/runInputs125X.py
   version: v100B
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fpinputs
   ncpu: 1
   output_file_name: inputs125X.root
+
+Configuration:
+  - mode: INFP
+    cmssw_config: ../FastPUPPI/NtupleProducer/python/runInputs125X.py
 
 DoubleElectron_FlatPt-1To100_PU0:
   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD

--- a/submit_INFP_131X.yaml
+++ b/submit_INFP_131X.yaml
@@ -15,14 +15,16 @@ Common:
     # - DYToLL_M50_PU200
     # # - ZprimeToEE_M-6000_PU200
 
-
   # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
-  cmssw_config: ../FastPUPPI/NtupleProducer/python/runInputs131X.py
   version: 131Xv3a
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fpinputs
   ncpu: 1
   output_file_name: inputs131X.root
   #storage_site: T2_UK_SGrid_RALPP
+
+Configuration:
+  - mode: INFP
+    cmssw_config: ../FastPUPPI/NtupleProducer/python/runInputs131X.py
 
 # DoubleElectron_FlatPt-1To100_PU0:
 #   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD

--- a/submit_INFP_131X.yaml
+++ b/submit_INFP_131X.yaml
@@ -5,10 +5,14 @@ Common:
   
   tasks:
     # - DYToLL_M50_PU0
-    # - DoubleElectron_FlatPt-1To100_PU0
+    # - HAHM_ZdToEE_m2_pu200
+    # - HAHM_ZdToEE_m5_pu200
+    # - HAHM_ZdToEE_m15_pu200
+    - DoubleElectron_FlatPt-1To100_PU0
     # - TT_PU200
     # # - DYToLL_PU200
-    # - DoubleElectron_FlatPt-1To100_PU200
+    - DoubleElectron_FlatPt-1To100_PU200
+    - VBF_HToInvisible_PU200
     # - DoublePhoton_FlatPt-1To100_PU200
     # - NuGunAllEta_PU200
     # - DYToLL_M10To50_PU200
@@ -16,9 +20,10 @@ Common:
     # # - ZprimeToEE_M-6000_PU200
 
   # cmssw_config: ../Phase2EGTriggerAnalysis/NtupleProducer/test/step1_L1TCorr_EGNtuples.py
-  version: 131Xv3a
+  version: 131Xv9a
   output_dir_base: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/fpinputs
-  ncpu: 1
+  ncpu: 4
+  max_memory: 7000
   output_file_name: inputs131X.root
   #storage_site: T2_UK_SGrid_RALPP
 
@@ -26,14 +31,26 @@ Configuration:
   - mode: INFP
     cmssw_config: ../FastPUPPI/NtupleProducer/python/runInputs131X.py
 
-# DoubleElectron_FlatPt-1To100_PU0:
-#   input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
-#   # input_directory =
-#   crab: True
-#   splitting_mode: Automatic
-#   splitting_granularity: 400
-#   # job_flavor =
-#   max_events: -1
+
+VBF_HToInvisible_PU200:
+  input_dataset: /VBF_HToInvisible_M-125_TuneCP5_14TeV-powheg-pythia8/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
+  # input_directory =
+  crab: True
+  splitting_mode: Automatic
+  splitting_granularity: 400
+  # job_flavor =
+  max_events: -1
+
+
+
+DoubleElectron_FlatPt-1To100_PU0:
+  input_dataset: /DoubleElectron_FlatPt-1To100-gun/Phase2Fall22DRMiniAOD-noPU_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
+  # input_directory =
+  crab: True
+  splitting_mode: Automatic
+  splitting_granularity: 400
+  # job_flavor =
+  max_events: -1
 
   
 DoubleElectron_FlatPt-1To100_PU200:
@@ -73,7 +90,8 @@ NuGunAllEta_PU200:
   splitting_mode: Automatic
   splitting_granularity: 400
   job_flavor: longlunch
-  max_events: 300000
+  max_events: -1
+  # max_events: 300000
 
 
 # /DYToLL_M-10To50_TuneCP5_14TeV-pythia8/Phase2Spring23DIGIRECOMiniAOD-PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/GEN-SIM-DIGI-RAW-MINIAOD
@@ -87,7 +105,8 @@ DYToLL_M10To50_PU200:
   splitting_mode: Automatic
   splitting_granularity: 400
   job_flavor: longlunch
-  max_events: 50000
+  max_events: -1
+  # max_events: 50000
 
 
 # DYToLL_M50_PU0:
@@ -104,7 +123,8 @@ DYToLL_M50_PU200:
   splitting_mode: Automatic
   splitting_granularity: 400
   job_flavor: longlunch
-  max_events: 50000
+  max_events: -1
+  # max_events: 50000
 
 # DYToLL_PU200:
 #   # input_dataset =
@@ -136,14 +156,33 @@ TT_PU200:
   splitting_mode: Automatic
   splitting_granularity: 400
   # job_flavor =
-  max_events: 100000
+  # max_events: 100000
+  max_events: -1
 
 
-# ZprimeToEE_M-6000_PU200:
-#   input_dataset: /ZprimeToEE_M-6000_TuneCP5_14TeV-pythia8/Phase2Fall22DRMiniAOD-PU200_125X_mcRun4_realistic_v2-v1/GEN-SIM-DIGI-RAW-MINIAOD
-#   # input_directory =
-#   crab: True
-#   splitting_mode: EventAwareLumiBased
-#   splitting_granularity: 4000
-#   # job_flavor =
-#   max_events: -1
+HAHM_ZdToEE_m2_pu200:
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/prod/HAHM_ZdToEE_m2_pu200/2STEPS/131X_Phase2Spring23_FEVTDEBUGHLT_v0
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 1
+  job_flavor: microcentury
+  max_events: -1
+  # max_njobs: 4
+
+HAHM_ZdToEE_m5_pu200:
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/prod/HAHM_ZdToEE_m5_pu200/2STEPS/131X_Phase2Spring23_FEVTDEBUGHLT_v0
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 1
+  job_flavor: microcentury
+  max_events: -1
+  # max_njobs: 4
+
+HAHM_ZdToEE_m15_pu200:
+  input_directory: /eos/cms/store/cmst3/group/l1tr/cerminar/l1teg/prod/HAHM_ZdToEE_m15_pu200/2STEPS/131X_Phase2Spring23_FEVTDEBUGHLT_v0
+  crab: False
+  splitting_mode: file_based
+  splitting_granularity: 1
+  job_flavor: microcentury
+  max_events: -1
+  # max_njobs: 4

--- a/templates/crab_INFP.py
+++ b/templates/crab_INFP.py
@@ -11,9 +11,9 @@ config.General.transferLogs = False
 
 config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = 'TEMPL_TASKCONFDIR/input_cfg.py'
-config.JobType.maxMemoryMB = 3000
-# config.JobType.numCores = 4
-# config.JobType.maxMemoryMB = 7000
+# config.JobType.maxMemoryMB = 3000
+config.JobType.numCores = TEMPL_NCPU
+config.JobType.maxMemoryMB = TEMPL_MEMORY
 
 config.Data.inputDBS = 'global'
 config.Data.splitting = 'TEMPL_SPLITTINGMODE'

--- a/templates/crab_NTP.py
+++ b/templates/crab_NTP.py
@@ -13,7 +13,9 @@ config.General.transferLogs = False
 
 config.JobType.pluginName = 'Analysis'
 config.JobType.psetName = 'TEMPL_TASKCONFDIR/input_cfg.py'
-config.JobType.maxMemoryMB = 3000
+# config.JobType.maxMemoryMB = 3000
+config.JobType.numCores = TEMPL_NCPU
+config.JobType.maxMemoryMB = TEMPL_MEMORY
 
 config.Data.inputDBS = 'global'
 config.Data.splitting = 'TEMPL_SPLITTINGMODE'

--- a/templates/jobCustomization_DEFAULT_cfg.py
+++ b/templates/jobCustomization_DEFAULT_cfg.py
@@ -4,4 +4,4 @@ from input_cfg import process
 
 process.maxEvents.input = cms.untracked.int32(TEMPL_NEVENTS)
 process.source.fileNames = cms.untracked.vstring(TEMPL_INFILES)
-process.TFileService.fileName = cms.string('TEMPL_OUTFILE')
+process.TFileService.fileName = cms.string('file:TEMPL_OUTFILE')

--- a/templates/jobCustomization_FEVTDEBUGHLT_cfg.py
+++ b/templates/jobCustomization_FEVTDEBUGHLT_cfg.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+from TEMPL_ROOTCFG import process
+
+
+process.source.fileNames = cms.untracked.vstring(TEMPL_INFILES)
+## Events and lumi blocks
+process.maxEvents.input = cms.untracked.int32(TEMPL_NEVENTS)
+
+## Scramble
+# import random
+# rnd = random.SystemRandom()
+for X in process.RandomNumberGeneratorService.parameterNames_(): 
+   if X != 'saveFileName': getattr(process.RandomNumberGeneratorService,X).initialSeed = cms.untracked.uint32(TEMPL_SEED)
+# 
+process.FEVTDEBUGHLToutput.fileName = cms.untracked.string('file:TEMPL_OUTFILE')
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(TEMPL_NCPU)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)

--- a/templates/jobCustomization_INFP.py
+++ b/templates/jobCustomization_INFP.py
@@ -5,3 +5,8 @@ from input_cfg import process
 process.maxEvents.input = cms.untracked.int32(TEMPL_NEVENTS)
 process.source.fileNames = cms.untracked.vstring(TEMPL_INFILES)
 process.out.fileName = cms.string('TEMPL_OUTFILE')
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(TEMPL_NCPU)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)

--- a/templates/jobCustomization_INFP_cfg.py
+++ b/templates/jobCustomization_INFP_cfg.py
@@ -4,9 +4,9 @@ from input_cfg import process
 
 process.maxEvents.input = cms.untracked.int32(TEMPL_NEVENTS)
 process.source.fileNames = cms.untracked.vstring(TEMPL_INFILES)
-process.out.fileName = cms.string('TEMPL_OUTFILE')
 
 #Setup FWK for multithreaded
 process.options.numberOfThreads=cms.untracked.uint32(TEMPL_NCPU)
 process.options.numberOfStreams=cms.untracked.uint32(0)
 process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
+process.out.fileName = cms.untracked.string('TEMPL_OUTFILE')

--- a/templates/jobCustomization_RAWSIM_cfg.py
+++ b/templates/jobCustomization_RAWSIM_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+from TEMPL_ROOTCFG import process
+
+
+process.source.fileNames = cms.untracked.vstring(TEMPL_INFILES)
+## Events and lumi blocks
+process.maxEvents.input = cms.untracked.int32(TEMPL_NEVENTS)
+if process.source.type_() != 'EmptySource':
+    process.source.skipEvents = cms.untracked.uint32(TEMPL_SKIPENVETS)
+process.source.firstLuminosityBlock = cms.untracked.uint32(TEMPL_FIRSTLUMI)
+## Scramble
+import random
+# rnd = random.SystemRandom()
+for X in process.RandomNumberGeneratorService.parameterNames_(): 
+   if X != 'saveFileName': getattr(process.RandomNumberGeneratorService,X).initialSeed = cms.untracked.uint32(TEMPL_SEED)
+# 
+process.RAWSIMoutput.fileName = cms.untracked.string('file:TEMPL_OUTFILE')
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(TEMPL_NCPU)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)

--- a/templates/run_2STEPS.sh
+++ b/templates/run_2STEPS.sh
@@ -43,11 +43,21 @@ cp ${ABSTASKCONFDIR}/job_config_step2_${PROCID}.py ${BATCH_DIR}/
 cd ${BATCH_DIR}
 ls -lrt
 echo 'now we run STEP1...fasten your seatbelt: '
-cmsRun job_config_step1_${PROCID}.py 2>&1 | tee step1_${PROCID}.${CLUSTERID}.log > /dev/null || { echo "STEP1 failed with exit code $?"; exit 11; }
+cmsRun job_config_step1_${PROCID}.py 2>&1 | tee step1_${PROCID}.${CLUSTERID}.log > /dev/null
+EXIT_CODE=${PIPESTATUS[0]}
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "STEP1 failed with exit code $EXIT_CODE"
+    exit 11
+fi
 gzip step1_${PROCID}.${CLUSTERID}.log && cp -v step1_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP1 log handling failed!'; exit 12; }
 echo '...done!'
 
 echo 'now we run STEP2...fasten your seatbelt: '
-cmsRun job_config_step2_${PROCID}.py 2>&1 | tee step2_${PROCID}.${CLUSTERID}.log > /dev/null || { echo "STEP2 failed with exit code $?"; exit 21; }
+cmsRun job_config_step2_${PROCID}.py 2>&1 | tee step2_${PROCID}.${CLUSTERID}.log > /dev/null
+EXIT_CODE=${PIPESTATUS[0]}
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "STEP2 failed with exit code $EXIT_CODE"
+    exit 21
+fi
 gzip step2_${PROCID}.${CLUSTERID}.log && cp -v step2_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP2 log handling failed!'; exit 22; }
 echo '...done!'

--- a/templates/run_2STEPS.sh
+++ b/templates/run_2STEPS.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+uname -a
+
+env
+
+CLUSTERID=$1
+PROCID=$2
+
+source ./params.sh
+
+
+BATCH_DIR=${PWD}
+
+
+echo "CLUSTER:" ${CLUSTERID}
+echo "PROC-ID" ${PROCID}
+echo 'TASKCONFDIR' ${ABSTASKCONFDIR}
+echo 'OUT-DIR' ${OUTDIR}
+echo 'OUTPUT-FILE' ${OUTFILE}
+
+#dump job info
+echo 'PROCID='${PROCID} >> job_info.sh
+echo 'CLUSTERID='${CLUSTERID} >> job_info.sh
+
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+export SCRAM_ARCH=${SCRAMARCH}
+scram proj CMSSW ${CMSSWVERSION}
+cd ${CMSSWVERSION}
+cp ../sandbox.tgz .
+# cp ${ABSTASKBASEDIR}/sandbox.tgz .
+tar xvf sandbox.tgz
+eval `scram runtime -sh`
+echo "SCRAM arch: ${SCRAM_ARCH} CMSSW version: ${CMSSWVERSION}"
+#cd ${ABSTASKCONFDIR}
+# cp ${ABSTASKCONFDIR}/input_cfg.pkl ${BATCH_DIR}/
+cp ${ABSTASKCONFDIR}/input_step1_cfg.py ${BATCH_DIR}/
+cp ${ABSTASKCONFDIR}/job_config_step1_${PROCID}.py ${BATCH_DIR}/
+
+cp ${ABSTASKCONFDIR}/input_step2_cfg.py ${BATCH_DIR}/
+cp ${ABSTASKCONFDIR}/job_config_step2_${PROCID}.py ${BATCH_DIR}/
+
+# python process_pickler.py job_config_${PROCID}.py ${BATCH_DIR}/job_config.py
+cd ${BATCH_DIR}
+ls -lrt
+echo 'now we run STEP1...fasten your seatbelt: '
+cmsRun job_config_step1_${PROCID}.py 2>&1 | tee step1_${PROCID}.${CLUSTERID}.log > /dev/null || { echo "STEP1 failed with exit code $?"; exit 11; }
+gzip step1_${PROCID}.${CLUSTERID}.log && cp -v step1_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP1 log handling failed!'; exit 12; }
+echo '...done!'
+
+echo 'now we run STEP2...fasten your seatbelt: '
+cmsRun job_config_step2_${PROCID}.py 2>&1 | tee step2_${PROCID}.${CLUSTERID}.log > /dev/null || { echo "STEP2 failed with exit code $?"; exit 21; }
+gzip step2_${PROCID}.${CLUSTERID}.log && cp -v step2_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP2 log handling failed!'; exit 22; }
+echo '...done!'

--- a/templates/run_2STEPS.sh
+++ b/templates/run_2STEPS.sh
@@ -45,19 +45,19 @@ ls -lrt
 echo 'now we run STEP1...fasten your seatbelt: '
 cmsRun job_config_step1_${PROCID}.py 2>&1 | tee step1_${PROCID}.${CLUSTERID}.log > /dev/null
 EXIT_CODE=${PIPESTATUS[0]}
+gzip step1_${PROCID}.${CLUSTERID}.log && cp -v step1_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP1 log handling failed!'; exit 12; }
 if [ $EXIT_CODE -ne 0 ]; then
     echo "STEP1 failed with exit code $EXIT_CODE"
     exit 11
 fi
-gzip step1_${PROCID}.${CLUSTERID}.log && cp -v step1_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP1 log handling failed!'; exit 12; }
 echo '...done!'
 
 echo 'now we run STEP2...fasten your seatbelt: '
 cmsRun job_config_step2_${PROCID}.py 2>&1 | tee step2_${PROCID}.${CLUSTERID}.log > /dev/null
 EXIT_CODE=${PIPESTATUS[0]}
+gzip step2_${PROCID}.${CLUSTERID}.log && cp -v step2_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP2 log handling failed!'; exit 22; }
 if [ $EXIT_CODE -ne 0 ]; then
     echo "STEP2 failed with exit code $EXIT_CODE"
     exit 21
 fi
-gzip step2_${PROCID}.${CLUSTERID}.log && cp -v step2_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'STEP2 log handling failed!'; exit 22; }
 echo '...done!'

--- a/templates/run_DEFAULT.sh
+++ b/templates/run_DEFAULT.sh
@@ -39,4 +39,11 @@ cp ${ABSTASKCONFDIR}/job_config_${PROCID}.py ${BATCH_DIR}/
 cd ${BATCH_DIR}
 ls -lrt
 echo 'now we run it...fasten your seatbelt: '
-cmsRun job_config_${PROCID}.py
+cmsRun job_config_${PROCID}.py 2>&1 | tee cmsRun_${PROCID}.${CLUSTERID}.log > /dev/null
+EXIT_CODE=${PIPESTATUS[0]}
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "cmsRun failed with exit code $EXIT_CODE"
+    exit 11
+fi
+gzip cmsRun_${PROCID}.${CLUSTERID}.log && cp -v cmsRun_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'cmsRun log handling failed!'; exit 12; }
+echo '...done'

--- a/templates/run_DEFAULT.sh
+++ b/templates/run_DEFAULT.sh
@@ -41,9 +41,9 @@ ls -lrt
 echo 'now we run it...fasten your seatbelt: '
 cmsRun job_config_${PROCID}.py 2>&1 | tee cmsRun_${PROCID}.${CLUSTERID}.log > /dev/null
 EXIT_CODE=${PIPESTATUS[0]}
+gzip cmsRun_${PROCID}.${CLUSTERID}.log && cp -v cmsRun_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'cmsRun log handling failed!'; exit 12; }
 if [ $EXIT_CODE -ne 0 ]; then
     echo "cmsRun failed with exit code $EXIT_CODE"
     exit 11
 fi
-gzip cmsRun_${PROCID}.${CLUSTERID}.log && cp -v cmsRun_${PROCID}.${CLUSTERID}.log.gz ${ABSTASKLOGDIR} || { echo 'cmsRun log handling failed!'; exit 12; }
 echo '...done'


### PR DESCRIPTION
Can now run 1 script that does several cmsRun steps (e.g., GEN,DIGI-RECO).

The format of the YAML file configuration changes in a non-backward compatible way.
(a `Configuration` section is now introduced).

The cmsRun logs when running on HT-Condor are now gzipped.
Parameters for handling the multithreading and memory requirements have been added.


