### PR TITLE
A few more features

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -110,6 +110,9 @@ class TaskConfig:
 
         for key, value in list(task_config.items()):
             setattr(self, key, value)
+        for key, value in list(common_config.items()):
+            if key not in task_config.keys():
+                setattr(self, key, value)
 
         self.task_base_dir = '{}/{}/'.format(
             common_config['name'],

--- a/submit.py
+++ b/submit.py
@@ -3,6 +3,7 @@
 import optparse
 import configparser
 import os
+import re
 import sys
 import shutil
 import subprocess
@@ -434,6 +435,12 @@ def createCondorConfig(mode, params):
     condor_template_file.close()
     condor_template = condor_template.replace('TEMPL_NJOBS', str(params['NJOBS']))
     templs_keys = [key for key in list(params.keys()) if 'TEMPL_' in key]
+    if "CMSSW_VERSION" in os.environ:
+        el_version = os.environ["SCRAM_ARCH"].split('_')[0]
+        if "MY.WantOS" in condor_template:
+            condor_template = re.sub(r"MY.WantOS\s*=\s*\"el\d+\"", f"MY.WantOS = \"{el_version}\"", condor_template)
+        else:
+            print("Warning: Could not set MY.WantOS in condor template.")
     for key in templs_keys:
         condor_template = condor_template.replace(key, str(params[key]))
 


### PR DESCRIPTION
 * allow taking defaults (e.g. `crab: False`) from Common part instead to have to repeat them for each task
 * for condor jobs with a CMSSW env, get the right EL flavour from SCRAM_ARCH
 * `job_based` splitting (for non-crab): 
    * specify total number of events (`max_events`) and jobs (`max_njobs`), and it distributes all files round-robin across the jobs and sets a max number of events per job so that the total matches the request. 
    * It does not guarantee to achieve the requested number of events total, but should work fine as long as the dataset has significantly more events than the total requested so that no job runs out of files before processing the requested number of events